### PR TITLE
fix: set fallbackLng and load: languageOnly to fix translations not rendering

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -8,7 +8,8 @@ void i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    fallbackLng: false,
+    fallbackLng: "en",
+    load: "languageOnly",
     returnEmptyString: false,
     interpolation: {
       escapeValue: false,


### PR DESCRIPTION
Fixes #17.

## What's wrong

When a browser reports a region-tagged locale (e.g. `en-US`), i18next tries to fetch `/locales/en-US/translation.json`. Vite's SPA fallback (and many static-hosting setups) return `index.html` for any unmatched path instead of a 404. i18next silently fails to parse that HTML as JSON, so the `en-US` resource is empty. With `fallbackLng: false`, there is no path to the successfully-loaded `en` translations, and every key is returned verbatim — the whole UI shows raw keys like `home.riichiTracker`, `home.newGame`, etc.

## The fix

```diff
// src/i18n.ts
 .init({
-  fallbackLng: false,
+  fallbackLng: "en",
+  load: "languageOnly",
   returnEmptyString: false,
```

- **`load: "languageOnly"`** — normalises `en-US` → `en` before making the fetch request, so i18next requests a file that actually exists and avoids the bad JSON parse entirely.
- **`fallbackLng: "en"`** — safety net: if any other locale has a missing or partial translation file, English strings are shown rather than raw keys.

## Testing

1. `npm install && npm run dev`
2. Open `http://localhost:5173` in a browser set to `en-US` (or any region-tagged locale).
3. All strings now render correctly instead of showing raw keys.